### PR TITLE
feat(CK-1): creating item and offer entity and create item endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazoncorretto:21-alpine
 VOLUME /tmp
 
 # Copy the built JAR file into the container
-COPY target/tisha-*.jar /app.jar
+COPY target/kata-*.jar /app.jar
 
 COPY src/main/resources/config/flyway/db/migration /app/resources/config/flyway/db/migration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ services:
    - "3306:3306"
   environment:
    MYSQL_ROOT_PASSWORD: root
-   MYSQL_DATABASE: checkout-kata
+   MYSQL_DATABASE: checkout_kata
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,26 @@
 			<artifactId>mariadb-java-client</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-settings</artifactId>
+			<version>4.0.0-alpha-4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-properties-migrator</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/checkout/kata/config/WebSecurityConfig.java
+++ b/src/main/java/com/checkout/kata/config/WebSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.checkout.kata.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) // CSRF disabled for APIs
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll() // Protect all other endpoints
+                );
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/checkout/kata/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/checkout/kata/exception/DefaultExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.checkout.kata.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(UseCaseException.class)
+    public ResponseEntity<Object> handleResourceException(UseCaseException ex){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+}

--- a/src/main/java/com/checkout/kata/exception/UseCaseException.java
+++ b/src/main/java/com/checkout/kata/exception/UseCaseException.java
@@ -1,0 +1,8 @@
+package com.checkout.kata.exception;
+
+public class UseCaseException extends RuntimeException{
+
+    public UseCaseException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/checkout/kata/item/domain/Item.java
+++ b/src/main/java/com/checkout/kata/item/domain/Item.java
@@ -1,0 +1,20 @@
+package com.checkout.kata.item.domain;
+
+import com.checkout.kata.offer.domain.Offer;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class Item {
+
+    private Long id;
+    private String name;
+    private BigDecimal unitPrice;
+    private Offer offer;
+
+}

--- a/src/main/java/com/checkout/kata/item/domain/dto/request/CreateItemRequest.java
+++ b/src/main/java/com/checkout/kata/item/domain/dto/request/CreateItemRequest.java
@@ -1,0 +1,25 @@
+package com.checkout.kata.item.domain.dto.request;
+
+import com.checkout.kata.offer.domain.dto.request.OfferRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class CreateItemRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private BigDecimal unitPrice;
+
+    private OfferRequest offer;
+
+}

--- a/src/main/java/com/checkout/kata/item/domain/dto/response/CreateItemResponse.java
+++ b/src/main/java/com/checkout/kata/item/domain/dto/response/CreateItemResponse.java
@@ -1,0 +1,19 @@
+package com.checkout.kata.item.domain.dto.response;
+
+import com.checkout.kata.offer.domain.dto.response.OfferResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class CreateItemResponse {
+
+    private Long id;
+    private String name;
+    private BigDecimal unitPrice;
+    private OfferResponse offer;
+}

--- a/src/main/java/com/checkout/kata/item/entity/ItemEntity.java
+++ b/src/main/java/com/checkout/kata/item/entity/ItemEntity.java
@@ -25,7 +25,6 @@ public class ItemEntity {
     @Column(name = "unit_price")
     private BigDecimal unitPrice;
 
-    @OneToOne
-    @JoinColumn(name = "offer_id")
+    @OneToOne(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
     private OfferEntity offer;
 }

--- a/src/main/java/com/checkout/kata/item/entity/ItemEntity.java
+++ b/src/main/java/com/checkout/kata/item/entity/ItemEntity.java
@@ -1,0 +1,31 @@
+package com.checkout.kata.item.entity;
+
+import com.checkout.kata.offer.entity.OfferEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "T_ITEM")
+@NoArgsConstructor
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "unit_price")
+    private BigDecimal unitPrice;
+
+    @OneToOne
+    @JoinColumn(name = "offer_id")
+    private OfferEntity offer;
+}

--- a/src/main/java/com/checkout/kata/item/persistence/DefaultReadItemStorageService.java
+++ b/src/main/java/com/checkout/kata/item/persistence/DefaultReadItemStorageService.java
@@ -1,0 +1,16 @@
+package com.checkout.kata.item.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultReadItemStorageService implements ReadItemStorageService {
+
+    private final ItemEntityRepository itemEntityRepository;
+
+    @Override
+    public boolean existsByName(String name) {
+        return itemEntityRepository.existsByName(name);
+    }
+}

--- a/src/main/java/com/checkout/kata/item/persistence/DefaultWriteItemStorageService.java
+++ b/src/main/java/com/checkout/kata/item/persistence/DefaultWriteItemStorageService.java
@@ -1,0 +1,30 @@
+package com.checkout.kata.item.persistence;
+
+import com.checkout.kata.exception.UseCaseException;
+import com.checkout.kata.item.domain.Item;
+import com.checkout.kata.item.entity.ItemEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+class DefaultWriteItemStorageService implements WriteItemStorageService {
+
+    private final ItemEntityRepository itemEntityRepository;
+    private final ItemEntityMapper itemEntityMapper;
+
+    @Override
+    public Item create(Item item) {
+        ItemEntity entityToSave = itemEntityMapper.mapToEntity(item);
+        return itemEntityMapper.mapToDomain(itemEntityRepository.save(entityToSave));
+    }
+
+    @Override
+    public Item update(Item item) {
+        ItemEntity existingEntity = itemEntityRepository.findByName(item.getName())
+                .orElseThrow(() -> new UseCaseException("Cannot find item with name: " + item.getName()));
+
+        itemEntityMapper.mapToEntity(existingEntity, item);
+        return itemEntityMapper.mapToDomain(itemEntityRepository.save(existingEntity));
+    }
+}

--- a/src/main/java/com/checkout/kata/item/persistence/ItemEntityMapper.java
+++ b/src/main/java/com/checkout/kata/item/persistence/ItemEntityMapper.java
@@ -1,0 +1,57 @@
+package com.checkout.kata.item.persistence;
+
+import com.checkout.kata.item.domain.Item;
+import com.checkout.kata.item.entity.ItemEntity;
+import com.checkout.kata.offer.domain.Offer;
+import com.checkout.kata.offer.entity.OfferEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+class ItemEntityMapper {
+
+    public ItemEntity mapToEntity(Item item){
+        ItemEntity entity = new ItemEntity();
+        entity.setId(item.getId());
+        entity.setName(item.getName());
+        entity.setUnitPrice(item.getUnitPrice());
+        entity.setOffer(mapToOfferEntity(item.getOffer(), entity));
+        return entity;
+    }
+
+    public void mapToEntity(ItemEntity savedEntity, Item item){
+        savedEntity.setUnitPrice(item.getUnitPrice());
+        savedEntity.setOffer(mapToOfferEntity(item.getOffer(), savedEntity));
+    }
+
+    private OfferEntity mapToOfferEntity(Offer offer, ItemEntity itemEntity){
+        if(offer == null){
+            return null;
+        }
+        OfferEntity offerEntity = new OfferEntity();
+        offerEntity.setId(offer.getId());
+        offerEntity.setQuantity(offer.getQuantity());
+        offerEntity.setDiscountPrice(offer.getDiscountPrice());
+        offerEntity.setItem(itemEntity);
+        return offerEntity;
+    }
+
+    public Item mapToDomain(ItemEntity entity){
+        return Item.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .unitPrice(entity.getUnitPrice())
+                .offer(mapToOfferDomain(entity.getOffer()))
+                .build();
+    }
+
+    private Offer mapToOfferDomain(OfferEntity offerEntity){
+        if(offerEntity == null){
+            return null;
+        }
+        return Offer.builder()
+                .id(offerEntity.getId())
+                .quantity(offerEntity.getQuantity())
+                .discountPrice(offerEntity.getDiscountPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/checkout/kata/item/persistence/ItemEntityRepository.java
+++ b/src/main/java/com/checkout/kata/item/persistence/ItemEntityRepository.java
@@ -3,5 +3,11 @@ package com.checkout.kata.item.persistence;
 import com.checkout.kata.item.entity.ItemEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ItemEntityRepository extends JpaRepository<ItemEntity, Long> {
+
+    boolean existsByName(String name);
+
+    Optional<ItemEntity> findByName(String name);
 }

--- a/src/main/java/com/checkout/kata/item/persistence/ItemEntityRepository.java
+++ b/src/main/java/com/checkout/kata/item/persistence/ItemEntityRepository.java
@@ -1,0 +1,7 @@
+package com.checkout.kata.item.persistence;
+
+import com.checkout.kata.item.entity.ItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemEntityRepository extends JpaRepository<ItemEntity, Long> {
+}

--- a/src/main/java/com/checkout/kata/item/persistence/ReadItemStorageService.java
+++ b/src/main/java/com/checkout/kata/item/persistence/ReadItemStorageService.java
@@ -1,0 +1,6 @@
+package com.checkout.kata.item.persistence;
+
+public interface ReadItemStorageService {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/checkout/kata/item/persistence/WriteItemStorageService.java
+++ b/src/main/java/com/checkout/kata/item/persistence/WriteItemStorageService.java
@@ -1,0 +1,10 @@
+package com.checkout.kata.item.persistence;
+
+import com.checkout.kata.item.domain.Item;
+
+public interface WriteItemStorageService {
+
+    Item create(Item item);
+
+    Item update(Item item);
+}

--- a/src/main/java/com/checkout/kata/item/rest/ItemController.java
+++ b/src/main/java/com/checkout/kata/item/rest/ItemController.java
@@ -1,0 +1,22 @@
+package com.checkout.kata.item.rest;
+
+import com.checkout.kata.item.domain.dto.request.CreateItemRequest;
+import com.checkout.kata.item.domain.dto.response.CreateItemResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/item")
+@RequiredArgsConstructor
+public class ItemController {
+
+    @PostMapping
+    public ResponseEntity<CreateItemResponse> createItem(@RequestBody @Valid CreateItemRequest createItemRequest){
+        return null;
+    }
+}

--- a/src/main/java/com/checkout/kata/item/rest/ItemController.java
+++ b/src/main/java/com/checkout/kata/item/rest/ItemController.java
@@ -15,8 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ItemController {
 
+    private final ItemGateway itemGateway;
+
     @PostMapping
-    public ResponseEntity<CreateItemResponse> createItem(@RequestBody @Valid CreateItemRequest createItemRequest){
-        return null;
+    public ResponseEntity<CreateItemResponse> upsertItem(@RequestBody @Valid CreateItemRequest createItemRequest){
+        return ResponseEntity.ok(itemGateway.upsertItem(createItemRequest));
     }
 }

--- a/src/main/java/com/checkout/kata/item/rest/ItemDomainMapper.java
+++ b/src/main/java/com/checkout/kata/item/rest/ItemDomainMapper.java
@@ -1,0 +1,52 @@
+package com.checkout.kata.item.rest;
+
+import com.checkout.kata.item.domain.Item;
+import com.checkout.kata.item.domain.dto.request.CreateItemRequest;
+import com.checkout.kata.item.domain.dto.response.CreateItemResponse;
+import com.checkout.kata.offer.domain.Offer;
+import com.checkout.kata.offer.domain.dto.request.OfferRequest;
+import com.checkout.kata.offer.domain.dto.response.OfferResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemDomainMapper {
+
+    public Item mapToDomain(CreateItemRequest createItemRequest){
+        return Item.builder()
+                .name(createItemRequest.getName())
+                .unitPrice(createItemRequest.getUnitPrice())
+                .offer(mapToOfferDomain(createItemRequest.getOffer()))
+                .build();
+    }
+
+    public CreateItemResponse mapToResponse(Item item){
+        return CreateItemResponse.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .unitPrice(item.getUnitPrice())
+                .offer(mapToOfferResponse(item.getOffer()))
+                .build();
+    }
+
+    private OfferResponse mapToOfferResponse(Offer offer){
+        if(offer == null){
+            return null;
+        }
+        return OfferResponse.builder()
+                .id(offer.getId())
+                .quantity(offer.getQuantity())
+                .discountPrice(offer.getDiscountPrice())
+                .build();
+    }
+
+    private Offer mapToOfferDomain(OfferRequest offerRequest){
+        if(offerRequest == null){
+            return null;
+        }
+        return Offer.builder()
+                .quantity(offerRequest.getQuantity())
+                .discountPrice(offerRequest.getDiscountPrice())
+                .build();
+    }
+
+}

--- a/src/main/java/com/checkout/kata/item/rest/ItemGateway.java
+++ b/src/main/java/com/checkout/kata/item/rest/ItemGateway.java
@@ -1,0 +1,22 @@
+package com.checkout.kata.item.rest;
+
+import com.checkout.kata.item.domain.Item;
+import com.checkout.kata.item.domain.dto.request.CreateItemRequest;
+import com.checkout.kata.item.domain.dto.response.CreateItemResponse;
+import com.checkout.kata.item.service.UpsertItemUseCaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class ItemGateway {
+
+    private final UpsertItemUseCaseService upsertItemUseCaseService;
+    private final ItemDomainMapper itemDomainMapper;
+
+    public CreateItemResponse upsertItem(CreateItemRequest createItemRequest){
+        Item item = itemDomainMapper.mapToDomain(createItemRequest);
+        Item savedItem = upsertItemUseCaseService.handle(item);
+        return itemDomainMapper.mapToResponse(savedItem);
+    }
+}

--- a/src/main/java/com/checkout/kata/item/service/DefaultUpsertItemUseCaseService.java
+++ b/src/main/java/com/checkout/kata/item/service/DefaultUpsertItemUseCaseService.java
@@ -1,0 +1,23 @@
+package com.checkout.kata.item.service;
+
+import com.checkout.kata.item.domain.Item;
+import com.checkout.kata.item.persistence.ReadItemStorageService;
+import com.checkout.kata.item.persistence.WriteItemStorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+class DefaultUpsertItemUseCaseService implements UpsertItemUseCaseService {
+
+    private final WriteItemStorageService writeItemStorageService;
+    private final ReadItemStorageService readItemStorageService;
+
+    @Override
+    public Item handle(Item item) {
+        if(readItemStorageService.existsByName(item.getName())){
+            return writeItemStorageService.update(item);
+        }
+        return writeItemStorageService.create(item);
+    }
+}

--- a/src/main/java/com/checkout/kata/item/service/UpsertItemUseCaseService.java
+++ b/src/main/java/com/checkout/kata/item/service/UpsertItemUseCaseService.java
@@ -1,0 +1,9 @@
+package com.checkout.kata.item.service;
+
+import com.checkout.kata.item.domain.Item;
+
+public interface UpsertItemUseCaseService {
+
+    Item handle(Item item);
+
+}

--- a/src/main/java/com/checkout/kata/offer/domain/Offer.java
+++ b/src/main/java/com/checkout/kata/offer/domain/Offer.java
@@ -1,0 +1,18 @@
+package com.checkout.kata.offer.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class Offer {
+
+    private Long id;
+    private Long quantity;
+    private BigDecimal discountPrice;
+
+}

--- a/src/main/java/com/checkout/kata/offer/domain/dto/request/OfferRequest.java
+++ b/src/main/java/com/checkout/kata/offer/domain/dto/request/OfferRequest.java
@@ -1,0 +1,16 @@
+package com.checkout.kata.offer.domain.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class OfferRequest {
+
+    private Long quantity;
+    private BigDecimal discountPrice;
+}

--- a/src/main/java/com/checkout/kata/offer/domain/dto/response/OfferResponse.java
+++ b/src/main/java/com/checkout/kata/offer/domain/dto/response/OfferResponse.java
@@ -1,0 +1,17 @@
+package com.checkout.kata.offer.domain.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+public class OfferResponse {
+
+    private Long id;
+    private Long quantity;
+    private BigDecimal discountPrice;
+}

--- a/src/main/java/com/checkout/kata/offer/entity/OfferEntity.java
+++ b/src/main/java/com/checkout/kata/offer/entity/OfferEntity.java
@@ -1,0 +1,33 @@
+package com.checkout.kata.offer.entity;
+
+import com.checkout.kata.item.entity.ItemEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "T_OFFER")
+@NoArgsConstructor
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class OfferEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "item_id", nullable = false, unique = true)
+    private ItemEntity item;
+
+    @Column(name = "quantity", nullable = false)
+    private Long quantity;
+
+    @Column(name = "discount_price", nullable = false)
+    private BigDecimal discountPrice;
+
+
+}

--- a/src/main/java/com/checkout/kata/offer/entity/OfferEntity.java
+++ b/src/main/java/com/checkout/kata/offer/entity/OfferEntity.java
@@ -20,7 +20,7 @@ public class OfferEntity {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "item_id", nullable = false, unique = true)
+    @JoinColumn(name = "item_id")
     private ItemEntity item;
 
     @Column(name = "quantity", nullable = false)

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -9,10 +9,10 @@ spring:
       ddl-auto: none
   datasource:
     primary:
-      jdbc-url: jdbc:mysql://localhost:3306/checkout-kata
+      jdbc-url: jdbc:mysql://localhost:3306/checkout_kata?allowPublicKeyRetrieval=true&useSSL=false
       username: root
       password: root
-      databaseName: checkout-kata
+      databaseName: checkout_kata
       driver-class-name: com.mysql.cj.jdbc.Driver
       serverName:
       cachePrepStmts: true

--- a/src/main/resources/config/flyway/db/migration/V1.0__Init.sql
+++ b/src/main/resources/config/flyway/db/migration/V1.0__Init.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS T_ITEM
+(
+    id          BIGINT(20) NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(255) NOT NULL,
+    unit_price  decimal(19,2) NOT NULL,
+
+    PRIMARY KEY (id)
+)ENGINE=InnoDB DEFAULT CHARSET=UTF8;
+
+ALTER TABLE T_ITEM
+ADD CONSTRAINT unique_name UNIQUE (name);
+
+
+CREATE TABLE IF NOT EXISTS T_OFFER
+(
+    id          BIGINT(20) NOT NULL AUTO_INCREMENT,
+    quantity    BIGINT(20) NOT NULL,
+    discount_price  decimal(19,2) NOT NULL,
+    item_id     BIGINT(20) NOT NULL,
+
+    PRIMARY KEY (id),
+    CONSTRAINT `fk_offer__item` FOREIGN KEY (`item_id`) REFERENCES `T_ITEM` (`id`)
+)ENGINE=InnoDB DEFAULT CHARSET=UTF8;

--- a/src/test/java/com/checkout/kata/integration/item/ItemControllerIT.java
+++ b/src/test/java/com/checkout/kata/integration/item/ItemControllerIT.java
@@ -1,0 +1,123 @@
+package com.checkout.kata.integration.item;
+
+import com.checkout.kata.integration.IntegrationBaseTest;
+import com.checkout.kata.item.domain.dto.request.CreateItemRequest;
+import com.checkout.kata.item.entity.ItemEntity;
+import com.checkout.kata.item.persistence.ItemEntityRepository;
+import com.checkout.kata.offer.domain.dto.request.OfferRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+public class ItemControllerIT extends IntegrationBaseTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ItemEntityRepository itemEntityRepository;
+
+    @BeforeEach
+    void setup(){
+        List<ItemEntity> entities = itemEntityRepository.findAll();
+        assertTrue(entities.isEmpty());
+    }
+
+    @Test
+    void upsertItem_shouldCreateItemWithoutOffer_whenRequestIsValid() throws Exception {
+        CreateItemRequest request = buildItemRequest("Apple", BigDecimal.valueOf(10), null);
+
+        mockMvc.perform(
+                        post("/api/v1/item")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Apple"))
+                .andExpect(jsonPath("$.unitPrice").value(BigDecimal.valueOf(10)))
+                .andExpect(jsonPath("$.offer").isEmpty());
+    }
+
+    @Test
+    void upsertItem_shouldCreateItemWithOffer_whenRequestIsValid() throws Exception {
+        CreateItemRequest request = buildItemRequest("Banana", BigDecimal.valueOf(10),
+                OfferRequest.builder().quantity(2L).discountPrice(BigDecimal.valueOf(8)).build());
+
+        mockMvc.perform(
+                        post("/api/v1/item")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Banana"))
+                .andExpect(jsonPath("$.unitPrice").value(BigDecimal.valueOf(10)))
+                .andExpect(jsonPath("$.offer").isNotEmpty())
+                .andExpect(jsonPath("$.offer.quantity").value(2L))
+                .andExpect(jsonPath("$.offer.discountPrice").value(BigDecimal.valueOf(8)));
+
+    }
+
+    @Test
+    void upsertItem_shouldUpdateItem_whenItemAlreadyExist() throws Exception {
+
+        itemEntityRepository.save(buildItem());
+        List<ItemEntity> items = itemEntityRepository.findAll();
+        assertThat(items.size()).isEqualTo(1);
+        assertThat(items.getFirst().getName()).isEqualTo("Banana");
+        assertThat(items.getFirst().getUnitPrice().doubleValue()).isEqualTo(BigDecimal.valueOf(5).doubleValue());
+        assertNull(items.getFirst().getOffer());
+
+        CreateItemRequest request = buildItemRequest("Banana", BigDecimal.valueOf(10),
+                OfferRequest.builder().quantity(2L).discountPrice(BigDecimal.valueOf(8)).build());
+
+        mockMvc.perform(
+                        post("/api/v1/item")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Banana"))
+                .andExpect(jsonPath("$.unitPrice").value(BigDecimal.valueOf(10)))
+                .andExpect(jsonPath("$.offer").isNotEmpty())
+                .andExpect(jsonPath("$.offer.quantity").value(2L))
+                .andExpect(jsonPath("$.offer.discountPrice").value(BigDecimal.valueOf(8)));
+
+    }
+
+    private CreateItemRequest buildItemRequest(String name, BigDecimal unitPrice, OfferRequest offer){
+        return CreateItemRequest.builder()
+                .name(name)
+                .unitPrice(unitPrice)
+                .offer(offer)
+                .build();
+    }
+
+    private ItemEntity buildItem(){
+        ItemEntity item = new ItemEntity();
+        item.setName("Banana");
+        item.setUnitPrice(BigDecimal.valueOf(5.00));
+        return item;
+    }
+
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -1,0 +1,19 @@
+server:
+  port: 8080
+  shutdown: graceful
+
+spring:
+  jpa:
+    hibernate:
+      naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+      ddl-auto: none
+  flyway:
+    enabled: true
+    locations: classpath:/config/flyway/db/migration
+    out-of-order: true
+    baseline-on-migrate: true
+logging:
+  level:
+    org:
+      flywaydb: DEBUG
+


### PR DESCRIPTION
Upsert api is created using DDD clean code architecture where request is converted to domain object in gateway and domain object is mapped to entity in persistence(dao) level. So that in service level everything is done in domain object

Changed:
1. changed db name
2. fix config mistake
3. Flyway script to create item and offer entity
4. Upset item endpoint
5. Integration test added
6. web security config added
